### PR TITLE
Updates to two checklists

### DIFF
--- a/incident_response_checklist.md
+++ b/incident_response_checklist.md
@@ -18,7 +18,7 @@ For the engineer managing a production incident.
     - Impacts a single user (the user will need to be directly contacted)
         - <span style="color:darkorange">`8 hrs`</span> Daytime: contact a support specialist for assistance (slack @terrasupport in the JIRA ticket thread in #workbench-resilience). 
         - <span style="color:gold">`12 hrs`</span> Off-hours: Email the user and cc support@terra.bio . The email should explain the time the issue occurred, how the issue is impacting the user, and any relevant Terra details (workspace/submission/notebook/etc.) The Frontline support team will follow up with the user the next work day to answer any further questions.
-- <input type='checkbox'> **Set the _Users Informed_ field on the Jira bug to "Yes".**
+- <input type='checkbox'><span style="color:red">`immediately`</span> **Set the _Users Informed_ field on the Jira bug to "Yes".**
 - <input type='checkbox'> <span style="color:darkorange">`12 hrs`</span> (Blocker) <span style="color:gold">`48 hrs`</span> (Critical) **Oversee the remediation of the issue, returning the affected systems to normal.**  Follow steps in the [General Troubleshooting Playbook](https://docs.google.com/document/d/1KUdZBrnedzCCYQTNNmUCn_NVgTvfVKby_dyU7Laq5g0/edit#).
     - Note that "remediation" means that the system is back "up" and affected users are unblocked, not necessarily that the underlying cause has been fixed.
     - If there are additional actions to address root cause, track them as tickets on the appropriate Jira board.

--- a/manual_incident_checklist.md
+++ b/manual_incident_checklist.md
@@ -16,17 +16,21 @@ If you think you've discovered what is or could be an incident, follow the steps
     - This will alert the on-call engineer, who is responsible for overseeing incident response
 
 ## If you're Frontline Support or one of the portals (AoU, SCP)
-- <input type='checkbox'> **Make a ticket on the PROD board with details on the issue**
-	-  To the best of your ability, fill in the “Incident Start Time” field with the date and time the issue began and “Priority” according to the SLA.
-- <input type='checkbox'> **Contact Tier 3 Support to triage severity.**  With Tier 3, decide if it's a production incident and its category using the [incident definitions](https://docs.google.com/spreadsheets/d/1Qcfve-nHlS0Udq31nZlfwBDjguhsJ8sxm0Q7RqfZM8o/edit#gid=1440345288) 
-- <input type='checkbox'> If it's an incident **Tier 3 Support can escalate to the engineering team that can resolve the issue.** If no one responds, if they don't have time or can't help, contact the on-call engineer by following the instructions under “If it’s after hours”.
+- <input type='checkbox'> **Make a ticket on the [PROD board](https://broadworkbench.atlassian.net/jira/software/c/projects/PROD/boards/88) with details on the issue**
+	-  To the best of your ability, fill in the *Date Incident Identified* field with the date and time the issue was declared and *Priority* according to the [SLA](https://docs.google.com/spreadsheets/d/1Qcfve-nHlS0Udq31nZlfwBDjguhsJ8sxm0Q7RqfZM8o/edit#gid=380034970).
+	-  Set the *Teams* field to the team that is responsible for the affected part of the platform (best guess).
+	-  Add whatever information you have about the issue to the *Description* field. **If the issue is particularly urgent**, you can get in contact with the appropriate team or oncall engineer before you fill this in.
+- <input type='checkbox'> **If obviously a PROD incident, ping the sprint captain for the relevant team.** Tag them in the thread for the PROD ticket in #workbench-resilience. Let them know all of the information you have about the issue, or that you will be adding the details to the PROD ticket description.
+- <input type='checkbox'> **If ambiguous, contact Tier 3 Support to triage severity.**  With Tier 3, decide if it's a production incident and its category using the [incident definitions](https://docs.google.com/spreadsheets/d/1Qcfve-nHlS0Udq31nZlfwBDjguhsJ8sxm0Q7RqfZM8o/edit#gid=1440345288) 
+	- <input type='checkbox'> If it's an incident **Tier 3 Support can escalate to the engineering team that can resolve the issue.** If no one responds, if they don't have time or can't help, contact the on-call engineer by following the instructions under “If it’s after hours”.
+- <input type='checkbox'> **Prepare to work on user comms.** Use the [Terra/Firecloud Service Notification Process](https://broadworkbench.atlassian.net/wiki/spaces/FS/pages/2599780388/Terra+Firecloud+Service+Notification+Process).
 
 ## If you're a developer and you're investigating the issue
-- <input type='checkbox'> **Check if Frontline Support made a ticket on the PROD board.  Otherwise, make a [PROD](https://broadworkbench.atlassian.net/secure/RapidBoard.jspa?rapidView=88&projectKey=PROD) ticket with details on the issue.**
-	- This will automatically notify #workbench-resilience and frontline support
-	- To the best of your ability, fill in the "Incident Start Time" field with the date and time the issue began.
+- <input type='checkbox'> **Check if Frontline Support made a ticket on the [PROD board](https://broadworkbench.atlassian.net/jira/software/c/projects/PROD/boards/88).  If not, make a PROD ticket with details on the issue.**
+	- This will automatically notify #workbench-resilience
+	- To the best of your ability, fill in the *Incident Start Time* field with the date and time the issue began. The *Date Incident Identified* field can be set to the time the ticket was raised.
 - <input type='checkbox'> **During investigation, use the [incident definitions](https://docs.google.com/spreadsheets/d/1Qcfve-nHlS0Udq31nZlfwBDjguhsJ8sxm0Q7RqfZM8o/edit#gid=1440345288) to classify the issue.**
-	- If it's an incident, set the ticket's priority as "Blocker" or "Critical"
+	- If it's an incident, set the ticket's *Priority* as "Blocker" or "Critical"
 	- Otherwise, move the ticket to the Support board or another Jira project
 - <input type='checkbox'> If it's an incident, **follow the [incident response checklist](https://broadinstitute.github.io/checklists.github.io/incident_response_checklist.html) during remediation (skipping the PagerDuty steps)**
 


### PR DESCRIPTION
Updating for accuracy of Frontline Support behavior around PROD incidents. Also updated manual incident checklist to show that `Users Informed` should be marked as Yes as soon as comms go out.